### PR TITLE
Improve Events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Style/StringLiterals:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  x86_64-darwin-18
   x86_64-darwin-20
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ light.state.color_temp
 # => 3200
 
 light.state.brightness
-# => 255
+# => 100
 
 light.state.rgb
 # => { red: 255, green: 255, blue: 255 }
@@ -166,8 +166,8 @@ Wizrb::Lighting::Events::RefreshEvent.new
 # No arguments
 Wizrb::Lighting::Events::ResetEvent.new
 
-# Integer 10 - 255
-Wizrb::Lighting::Events::SetBrightnessEvent.new(255)
+# Integer 10 - 100
+Wizrb::Lighting::Events::SetBrightnessEvent.new(100)
 
 # Integer 1 - 255
 Wizrb::Lighting::Events::SetColdWhiteEvent.new(255)

--- a/lib/wizrb.rb
+++ b/lib/wizrb.rb
@@ -7,9 +7,9 @@ require_relative 'wizrb/lighting/discover'
 require_relative 'wizrb/lighting/group'
 require_relative 'wizrb/lighting/state'
 
-Dir["#{File.dirname(__FILE__)}/wizrb/lighting/products/*.rb"].each { |file| require file }
-Dir["#{File.dirname(__FILE__)}/wizrb/lighting/events/*.rb"].each { |file| require file }
-Dir["#{File.dirname(__FILE__)}/wizrb/lighting/scenes/*.rb"].each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/wizrb/lighting/products/*.rb"].sort.each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/wizrb/lighting/events/*.rb"].sort.each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/wizrb/lighting/scenes/*.rb"].sort.each { |file| require file }
 
 module Wizrb
   class Error < StandardError; end

--- a/lib/wizrb/lighting/events/set_brightness_event.rb
+++ b/lib/wizrb/lighting/events/set_brightness_event.rb
@@ -6,15 +6,20 @@ module Wizrb
   module Lighting
     module Events
       class SetBrightnessEvent < Wizrb::Lighting::Events::Event
+        MIN_VALUE = 10
+        MAX_VALUE = 100
+
         def initialize(value)
           validate!(value)
-          super(method: 'setState', params: { dimming: ((value / 255.0) * 100).round })
+          super(method: 'setState', params: { dimming: value.to_i })
         end
 
         private
 
         def validate!(value)
-          raise ArgumentError, 'Brightness must be between 10 and 255' if !value || value < 10 || value > 255
+          return if value && value >= MIN_VALUE && value <= MAX_VALUE
+
+          raise ArgumentError, "Brightness must be an integer between #{MIN_VALUE} and #{MAX_VALUE}"
         end
       end
     end

--- a/lib/wizrb/lighting/events/set_cold_white_event.rb
+++ b/lib/wizrb/lighting/events/set_cold_white_event.rb
@@ -6,6 +6,9 @@ module Wizrb
   module Lighting
     module Events
       class SetColdWhiteEvent < Wizrb::Lighting::Events::Event
+        MIN_VALUE = 1
+        MAX_VALUE = 255
+
         def initialize(value)
           validate!(value)
           super(method: 'setState', params: { c: value })
@@ -14,7 +17,9 @@ module Wizrb
         private
 
         def validate!(value)
-          raise ArgumentError, 'Cold white must be between 1 and 255' if !value || value < 1 || value > 255
+          return if value && value >= MIN_VALUE && value <= MAX_VALUE
+
+          raise ArgumentError, "Cold white must be between #{MIN_VALUE} and #{MAX_VALUE}"
         end
       end
     end

--- a/lib/wizrb/lighting/events/set_color_temp_event.rb
+++ b/lib/wizrb/lighting/events/set_color_temp_event.rb
@@ -6,6 +6,9 @@ module Wizrb
   module Lighting
     module Events
       class SetColorTempEvent < Wizrb::Lighting::Events::Event
+        MIN_VALUE = 1000
+        MAX_VALUE = 12_000
+
         def initialize(value)
           validate!(value)
           super(method: 'setState', params: { temp: value })
@@ -14,8 +17,8 @@ module Wizrb
         private
 
         def validate!(value)
-          if !value || value < 1000 || value > 10_000
-            raise ArgumentError, 'Temperature must be between 1000 and 10000 kelvin'
+          if !value || value < MIN_VALUE || value > MAX_VALUE
+            raise ArgumentError, "Temperature must be between #{MIN_VALUE} and #{MAX_VALUE} kelvin"
           end
 
           raise ArgumentError, 'Temperature must be divisible by 100' unless value % 100 == 0

--- a/lib/wizrb/lighting/events/set_rgb_event.rb
+++ b/lib/wizrb/lighting/events/set_rgb_event.rb
@@ -6,6 +6,9 @@ module Wizrb
   module Lighting
     module Events
       class SetRgbEvent < Wizrb::Lighting::Events::Event
+        MIN_VALUE = 1
+        MAX_VALUE = 255
+
         def initialize(red, green, blue)
           validate_color!('Red', red)
           validate_color!('Green', green)
@@ -16,7 +19,9 @@ module Wizrb
         private
 
         def validate_color!(color, value)
-          raise ArgumentError, "#{color} must be between 0 and 255" if !value || value < 0 || value > 255
+          return if value && value >= MIN_VALUE && value <= MAX_VALUE
+
+          raise ArgumentError, "#{color} must be between #{MIN_VALUE} and #{MAX_VALUE}"
         end
       end
     end

--- a/lib/wizrb/lighting/events/set_speed_event.rb
+++ b/lib/wizrb/lighting/events/set_speed_event.rb
@@ -6,6 +6,9 @@ module Wizrb
   module Lighting
     module Events
       class SetSpeedEvent < Wizrb::Lighting::Events::Event
+        MIN_VALUE = 10
+        MAX_VALUE = 200
+
         def initialize(value)
           validate!(value)
           super(method: 'setState', params: { speed: value })
@@ -14,7 +17,9 @@ module Wizrb
         private
 
         def validate!(value)
-          raise ArgumentError, 'Speed must be between 10 and 200' if !value || value < 10 || value > 200
+          return if value && value >= MIN_VALUE && value <= MAX_VALUE
+
+          raise ArgumentError, "Speed must be between #{MIN_VALUE} and #{MAX_VALUE}"
         end
       end
     end

--- a/lib/wizrb/lighting/events/set_warm_white_event.rb
+++ b/lib/wizrb/lighting/events/set_warm_white_event.rb
@@ -6,6 +6,9 @@ module Wizrb
   module Lighting
     module Events
       class SetWarmWhiteEvent < Wizrb::Lighting::Events::Event
+        MIN_VALUE = 1
+        MAX_VALUE = 255
+
         def initialize(value)
           validate!(value)
           super(method: 'setState', params: { w: value })
@@ -14,7 +17,9 @@ module Wizrb
         private
 
         def validate!(value)
-          raise ArgumentError, 'Warm white must be between 1 and 255' if !value || value < 1 || value > 255
+          return if value && value >= MIN_VALUE && value <= MAX_VALUE
+
+          raise ArgumentError, "Warm white must be between #{MIN_VALUE} and #{MAX_VALUE}"
         end
       end
     end

--- a/lib/wizrb/lighting/products/light.rb
+++ b/lib/wizrb/lighting/products/light.rb
@@ -81,6 +81,30 @@ module Wizrb
           self
         end
 
+        def brightness(value)
+          dispatch_event(Wizrb::Lighting::Events::SetBrightnessEvent.new(value))
+        end
+
+        def cold_white(value)
+          dispatch_event(Wizrb::Lighting::Events::SetColdWhiteEvent.new(value))
+        end
+
+        def color_temp(value)
+          dispatch_event(Wizrb::Lighting::Events::SetColorTempEvent.new(value))
+        end
+
+        def rgb(red, green, blue)
+          dispatch_event(Wizrb::Lighting::Events::SetRgbEvent.new(red, green, blue))
+        end
+
+        def speed(value)
+          dispatch_event(Wizrb::Lighting::Events::SetSpeedEvent.new(value))
+        end
+
+        def warm_white(value)
+          dispatch_event(Wizrb::Lighting::Events::SetWarmWhiteEvent.new(value))
+        end
+
         def dispatch_event(event)
           unless event.is_a?(Wizrb::Lighting::Events::Event)
             raise ArgumentError, 'Not an instance of Wizrb::Lighting::Events::Event'

--- a/lib/wizrb/lighting/scenes/scene.rb
+++ b/lib/wizrb/lighting/scenes/scene.rb
@@ -22,6 +22,7 @@ module Wizrb
             before_start
             step while @running
             after_stop
+          ensure
             restore_state if @save
           end
         end

--- a/wizrb.gemspec
+++ b/wizrb.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Manage the state of your Philips WiZ devices.'
   spec.homepage      = 'https://github.com/bert-mccutchen/wizrb'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/bert-mccutchen/wizrb'


### PR DESCRIPTION
## Why are these changes being made?
It was discovered by @ppostma that the minimum-maximum of brightness events was wrong, and strange. Also the minimum required Ruby version was higher than it needed to be.

## Changes
* Lowered required Ruby version to 2.5.
* Fixed min-max for events.
* Added helper event methods.

## Requirements Checklist

#### Linters:
* [x] Rubocop has been run on these changes.
* [ ] Not required.

#### Documentation:
* [x] Has been updated.
* [ ] Not required.
