### PR TITLE
Fix return value of `State#brightness` when dimming is at its lowest value

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,10 @@ Style/Documentation:
 Style/NumericPredicate:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Metrics/CyclomaticComplexity:
   Enabled: false
 

--- a/lib/wizrb/lighting/connection.rb
+++ b/lib/wizrb/lighting/connection.rb
@@ -36,7 +36,7 @@ module Wizrb
 
           Timeout.timeout(timeout, Wizrb::ConnectionTimeoutError) do
             data, _addr = @socket.recvfrom(max)
-            log("Recieved: #{data}")
+            log("Received: #{data}")
             parse_response(data)
           end
         end

--- a/lib/wizrb/lighting/state.rb
+++ b/lib/wizrb/lighting/state.rb
@@ -40,7 +40,7 @@ module Wizrb
       end
 
       def brightness
-        if @state[:dimming] <= 10
+        if @state[:dimming] < 10
           @state[:dimming].to_i * 10
         else
           @state[:dimming]

--- a/lib/wizrb/lighting/state.rb
+++ b/lib/wizrb/lighting/state.rb
@@ -40,11 +40,7 @@ module Wizrb
       end
 
       def brightness
-        if @state[:dimming] < 10
-          @state[:dimming].to_i * 10
-        else
-          @state[:dimming]
-        end
+        @state[:dimming]
       end
 
       def speed

--- a/spec/fixtures/getPilot-1.json
+++ b/spec/fixtures/getPilot-1.json
@@ -1,0 +1,1 @@
+{"method":"getPilot","env":"pro","result":{"mac":"abcdefabcdef","rssi":-67,"src":"","state":true,"sceneId":0,"temp":2000,"dimming":10}}

--- a/spec/wizrb/lighting/state_spec.rb
+++ b/spec/wizrb/lighting/state_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Wizrb::Lighting::State do
+  subject(:state) { described_class.new }
+
+  let(:response) { JSON.parse(File.read('spec/fixtures/getPilot-1.json')) }
+
+  before { state.parse!(response) }
+
+  describe '#brightness' do
+    it 'returns the minimum brightness' do
+      expect(state.brightness).to eq(10)
+    end
+  end
+
+  describe '#power' do
+    it 'returns the power state' do
+      expect(state.power).to be true
+    end
+  end
+
+  describe '#color_temp' do
+    it 'returns the color temperature' do
+      expect(state.color_temp).to eq(2000)
+    end
+  end
+
+  describe '#scene' do
+    it 'returns nil when scene is not present' do
+      expect(state.scene).to be nil
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns a string representation of the state' do
+      expect(state.to_s).to eq('{:state=>true, :temp=>2000, :dimming=>10}')
+    end
+  end
+
+  describe '#to_json' do
+    it 'returns a JSON representation of the state' do
+      expect(state.to_json).to eq('{"state":true,"temp":2000,"dimming":10}')
+    end
+  end
+end


### PR DESCRIPTION
Add specs for `State` using a fixture for the getPilot response.