### PR TITLE
Faster timeout when device is not responding

### DIFF
--- a/lib/wizrb/lighting/products/light.rb
+++ b/lib/wizrb/lighting/products/light.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'socket'
-require 'timeout'
 require_relative '../../shared/products/device'
 require_relative '../state'
 

--- a/lib/wizrb/shared/discover.rb
+++ b/lib/wizrb/shared/discover.rb
@@ -2,7 +2,6 @@
 
 require 'ipaddr'
 require 'socket'
-require 'timeout'
 require 'json'
 require_relative 'group'
 require_relative 'products/device'

--- a/lib/wizrb/shared/products/device.rb
+++ b/lib/wizrb/shared/products/device.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'socket'
-require 'timeout'
 require_relative '../connection'
 require_relative '../state'
 require_relative '../events/base'
@@ -98,7 +97,7 @@ module Wizrb
 
         def dispatch(data)
           @connection.send(data)
-          @connection.recieve(timeout: 10, max: 65_536)
+          @connection.receive(timeout: 5, max: 65_536)
         end
       end
     end

--- a/spec/wizrb/shared/connection_spec.rb
+++ b/spec/wizrb/shared/connection_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Wizrb::Shared::Connection do
     # TODO
   end
 
-  xdescribe '#recieve' do
+  xdescribe '#receive' do
     # TODO
   end
 


### PR DESCRIPTION
Sometimes my lights are physically powered off and thus not reachable. Then timeout of 10 seconds seems to be a bit long so I changed it to five seconds.

Also removed the Timeout API (which is considered [a dangerous API by some people](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)) to use `IO#wait_readable`.